### PR TITLE
Allow to use slashes in the API declaration

### DIFF
--- a/src/fnhouse/swagger.clj
+++ b/src/fnhouse/swagger.clj
@@ -54,10 +54,11 @@
   [[:resources swagger]]
   (ring-swagger/api-listing {} swagger))
 
-(defnk $api-docs$:resource$GET
+(defnk $api-docs$:**$GET
   "Apidoc"
   {:responses {200 s/Any}}
-  [[:request [:uri-args resource :- String] :as request]
+  [[:request uri-args :as request]
    [:resources swagger]]
-  (ring-swagger/api-declaration {} swagger resource
-    (ring-swagger/basepath request)))
+  (let [resource (safe-get uri-args :**)]
+    (ring-swagger/api-declaration {} swagger resource
+      (ring-swagger/basepath request))))


### PR DESCRIPTION
According to Swagger v1.2 spec, API docs consist of Resource Listing and API Declaration. In some cases it's handy to have Resources prefixed. However, current version of fnhouse-swagger can't do this, because fnhouse's router will pass `api` for `:uri-args` if resource path is `/api/foobar` and this will result in 404. This PR fixes the issue using :*\* variable.

The other way around would be to allow custom `context` in `ring.swagger.core/basepath`, but it's a separate issue.
