### PR TITLE
Enable Swagger's OAuth2 support

### DIFF
--- a/examples/guesthouse/src/guesthouse/core.clj
+++ b/examples/guesthouse/src/guesthouse/core.clj
@@ -36,6 +36,7 @@
     (-> resources
         (assoc :api-docs all-docs)
         (assoc :swagger swagger)
+        (assoc :swagger-parameters {})
         ((handlers/curry-resources proto-handlers)))))
 
 (defn wrapped-root-handler

--- a/src/fnhouse/swagger.clj
+++ b/src/fnhouse/swagger.clj
@@ -63,14 +63,14 @@
 (defnk $api-docs$GET
   "Apidocs"
   {:responses {200 s/Any}}
-  [[:resources swagger swagger-parameters]]
+  [[:resources swagger {swagger-parameters {}}]]
   (ring-swagger/api-listing swagger-parameters swagger))
 
 (defnk $api-docs$:**$GET
   "Apidoc"
   {:responses {200 s/Any}}
   [[:request uri-args :as request]
-   [:resources swagger swagger-parameters]]
+   [:resources swagger {swagger-parameters {}}]]
   (let [resource (safe-get uri-args :**)]
     (ring-swagger/api-declaration swagger-parameters swagger resource
       (ring-swagger/basepath request))))


### PR DESCRIPTION
This PR is a part of a changeset that is required to support OAuth2-protected API. Main PR: https://github.com/metosin/ring-swagger/pull/25

Two changes are introduced by this PR:
- additional arity is added to fnhouse.swagger/collect-routes. New
  parameter is a function from handler's annotation to swagger's metadata.
  It complements fnhouse's extra-info-fn, allowing to control Swagger
  spec from a code that uses fnhouse-swagger.
- swagger-parameters map is now expected in resources. It will be
  passed to ring-swagger as-is.

NOTE: this is a breaking change, because swagger-parameters map should
be provided in resources. fnk's optional notation ({foo "bar"})
doesn't seem to work in parameters map, possibly due to fnhouse or fnk
bug.
